### PR TITLE
security: CVE-2026-48710 (BadHost) — floor Starlette >=1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- **Floor Starlette at `>=1.0.1` (CVE-2026-48710, "BadHost").** Starlette `< 1.0.1` fails to validate the Host header and poisons `request.url.path`, enabling path-based auth bypass in ASGI middleware. It reaches this server transitively via `fastmcp`/`mcp` (which floor it only at `>=0.27`); the resolved version was `0.52.1`. This server runs over stdio (FastMCP default `mcp.run()`), so it has no HTTP listener and the vector is not exploitable as shipped — this is hygiene: an explicit floor so the resolver cannot regress to a vulnerable build, and so a future SSE/HTTP transport does not inherit it. Local environments resolve to Starlette `1.2.1`.
+
 ### Added
 - **Transport-failure fallback** — opt-in routing of `403` / `429` / `503` to Firecrawl when `FALLBACK_ON_TRANSPORT_ERROR=true` and `FIRECRAWL_API_KEY` is set. Previously these statuses raised before the fallback could run. Resolves [#1].
 - **`POLITE_MODE` env flag** (default `true`) — on a `429` with a parseable `Retry-After`, the original request is retried once after the indicated wait, capped at `REQUEST_TIMEOUT` and clamped to non-negative.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,11 @@ classifiers = [
 ]
 dependencies = [
     "fastmcp>=2.0.0",
+    # Floor pinned for CVE-2026-48710 ("BadHost"): Starlette < 1.0.1 has a
+    # Host-header validation gap that poisons request.url.path. Pulled in
+    # transitively via fastmcp/mcp (which only floor it at >=0.27); this
+    # explicit floor stops the resolver from regressing to a vulnerable build.
+    "starlette>=1.0.1",
     "httpx>=0.27.0",
     "trafilatura>=1.12.0",
     "beautifulsoup4>=4.12.0",


### PR DESCRIPTION
## Summary

Floors Starlette at `>=1.0.1` for **CVE-2026-48710 ("BadHost")**.

Starlette `< 1.0.1` fails to validate the Host header and poisons `request.url.path`, enabling path-based auth bypass in ASGI middleware. It reaches this server transitively via `fastmcp`/`mcp` (which floor it only at `>=0.27`); the resolved version was `0.52.1`.

## Exposure

This server runs over **stdio** (FastMCP default `mcp.run()`), so it has no HTTP listener and the vector is **not exploitable as shipped**. This is hygiene: an explicit floor so the resolver can't regress to a vulnerable build, and so a future SSE/HTTP transport doesn't inherit it. Local environments resolve to Starlette `1.2.1`.

## Change

- `pyproject.toml`: `starlette>=1.0.1` floor with rationale comment.
- `CHANGELOG.md`: `### Security` entry.

## Tests

Suite: **22 passed.**
